### PR TITLE
Indicate on the home page that this software is for Windows.

### DIFF
--- a/index.md
+++ b/index.md
@@ -2,7 +2,7 @@
 title: Home
 permalink: /
 ---
-mRemoteNG is a fork of mRemote: an open source, tabbed, multi-protocol, remote connections manager. mRemoteNG adds bug fixes and new features to mRemote.
+mRemoteNG is a fork of mRemote: an open source, tabbed, multi-protocol, remote connections manager for Windows. mRemoteNG adds bug fixes and new features to mRemote.
 
 It allows you to view all of your remote connections in a simple yet powerful tabbed interface.
 


### PR DESCRIPTION
The home page doesn't currently indicate what platforms are supported. This change makes that information more discoverable.